### PR TITLE
staging: deploy frontend/ to Cloudflare Pages on PR

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,22 @@
+name: Deploy Frontend to Staging (CF Pages)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-staging.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to CF Pages (ottofloh-staging)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy frontend --project-name=ottofloh-staging --branch=main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,14 @@ gh-pages branch, assets/ folder  (JamesIves/github-pages-deploy-action, clean: f
   - **Geocoding API** (for the fallback in `kmzparser.py`)
   If only one is on, the build either renders a blank map (Geocoding off) or never gets to rendering (Static off). `REQUEST_DENIED` errors in the run log mean one of these is missing on the *correct* project — Cloud Console project selector gotcha.
 - `GITHUB_TOKEN` — standard, for the deploy action push to `gh-pages`.
-- `CLOUDFLARE_API_TOKEN` — used by `.github/workflows/deploy-worker.yml` to deploy the worker on `worker/**` pushes. Scope: Edit workers on the account owning `ottofloh-api`.
+- `CLOUDFLARE_API_TOKEN` — used by `.github/workflows/deploy-worker.yml` (worker) and `.github/workflows/deploy-staging.yml` (CF Pages staging deploy). Scopes required: `Workers Scripts:Edit` + `Cloudflare Pages:Edit`.
+- `CLOUDFLARE_ACCOUNT_ID` — used by `deploy-staging.yml`. Not secret (account IDs are fine to expose) but kept as a GH secret for consistency. Find it in CF dashboard → right sidebar.
+
+## Staging environment
+
+- Frontend preview: `https://ottofloh-staging.pages.dev/` (Cloudflare Pages, project `ottofloh-staging`).
+- `.github/workflows/deploy-staging.yml` runs on `pull_request` events touching `frontend/**` and deploys to the fixed `--branch=main` alias of the CF Pages project — i.e. **one staging URL, last PR wins**.
+- Backend (Phase 3, not yet wired): a separate staging Worker at `ottofloh-api-staging.kneunert.workers.dev` pointed at a separate Airtable base (`appaRNudq6rTsAl5z`) with its own ntfy topic (`ottofloh_alerts_staging`). Until Phase 3 lands, `frontend/registration.js` and `frontend/confirm.js` still talk to the **production** Worker — registrations made on the staging URL will hit prod Airtable and prod ntfy.
 
 ## Annual rebuild procedure (the ritual)
 
@@ -232,6 +239,7 @@ gh run view $(gh run list --workflow deploy.yml --limit 1 --json databaseId -q '
 - `src/config.py` — reads `api_key` from `secrets.yaml` (created fresh per workflow run from GH secret, gitignored locally).
 - `.github/workflows/deploy.yml` — the PDF/map workflow. Cron (every 6h) + push to `master` + manual. Pushes only `assets/` to `gh-pages` with `clean: false`.
 - `.github/workflows/deploy-frontend.yml` — mirrors `frontend/` to `gh-pages` on pushes to `master` touching `frontend/**`. Uses `JamesIves/github-pages-deploy-action@v4` with `clean: true` + `clean-exclude: [assets, kmz.hash]`.
+- `.github/workflows/deploy-staging.yml` — deploys `frontend/` to CF Pages project `ottofloh-staging` on `pull_request` events touching `frontend/**`. Fixed URL `ottofloh-staging.pages.dev` (last PR wins — see staging section).
 - `.github/workflows/deploy-worker.yml` — auto-deploys the Cloudflare Worker on pushes to `worker/**`. Uses `cloudflare/wrangler-action@v3` + `CLOUDFLARE_API_TOKEN` repo secret.
 - `frontend/` — the live site source. `index.html`, `confirm.html`, `registration.html`, all JS/CSS, `photos/`, `crp-photos/`, `favicon.svg`, `CNAME`. Edit here, commit, push — workflow mirrors to `gh-pages`.
 - `scripts/airtable_export.py` — downloads confirmed registrations from Airtable, normalizes addresses, outputs `build/airtable_raw.csv` + `build/airtable_export.csv`.


### PR DESCRIPTION
Phase 2 of the staging-system rollout (Phase 1 landed in #4).

## Summary

- Add `.github/workflows/deploy-staging.yml` — on `pull_request` events touching `frontend/**`, deploys `frontend/` to CF Pages project `ottofloh-staging` using `wrangler pages deploy --branch=main` (the production alias), giving a fixed URL `https://ottofloh-staging.pages.dev/`. One staging environment, last PR wins.
- `AGENTS.md`: secrets section, new staging env section, file reference updated.

## Status

- [x] Workflow run succeeded on first push — verified `https://ottofloh-staging.pages.dev/` returns HTTP 200 and serves the site.
- [x] `CLOUDFLARE_ACCOUNT_ID` turned out **not** to be required — the API token's account scope auto-resolves. The workflow references the secret as a no-op fallback; if set it's used, if unset (as today) wrangler infers. AGENTS.md kept the entry for clarity but nothing's broken without it.
- [x] `CLOUDFLARE_API_TOKEN` scopes verified (`Workers Scripts:Edit` + `Cloudflare Pages:Edit`).

## What this does NOT do (Phase 3 scope)

`frontend/registration.js` and `frontend/confirm.js` still hardcode the **production** Worker URL. Registrations submitted on `ottofloh-staging.pages.dev` will hit prod Airtable + prod ntfy. Phase 3 adds hostname-based API URL selection + a staging Worker env (`[env.staging]` in `worker/wrangler.toml`) + staging Airtable base (`appaRNudq6rTsAl5z`) + staging ntfy topic (`ottofloh_alerts_staging`).

## Test plan

- [x] Workflow run green on this PR
- [x] `https://ottofloh-staging.pages.dev/` loads the site
- [ ] Pushing a frontend change to this branch re-deploys staging (next commit will verify — currently not needed for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)